### PR TITLE
Support for Multi-Select Attributes (array) by converting to String values

### DIFF
--- a/app/code/Meta/Catalog/Model/Product/Feed/Builder/AdditionalAttributes.php
+++ b/app/code/Meta/Catalog/Model/Product/Feed/Builder/AdditionalAttributes.php
@@ -135,6 +135,7 @@ class AdditionalAttributes
             if (!$text) {
                 $text = $product->getData($attribute);
             }
+            if (is_array($text))  $text = implode(', ', $text);
             return $text;
         }
         return false;


### PR DESCRIPTION
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)

Add support for multi-select attributes (array), by converting them to string values

### Story

For this particular issue, the brand attribute has been made a multiselect, however it really is for any 

### Bug

Prevents product feed generation if the feed contains a multiselect attribute.
