### PR TITLE
get parent url if is available.

### DIFF
--- a/app/code/Meta/Catalog/Model/Product/Feed/Builder.php
+++ b/app/code/Meta/Catalog/Model/Product/Feed/Builder.php
@@ -261,9 +261,7 @@ class Builder
             ? $product->getData($this->attrMap[self::ATTR_URL])
             : null;
         if ($link == '' || $link == null) {
-            $parentUrl = $product->getParentProductUrl();
-            // use parent product URL if a simple product has a parent and is not visible individually
-            $url = (!$product->isVisibleInSiteVisibility() && $parentUrl) ? $parentUrl : $product->getProductUrl();
+            $url = $product->getParentProductUrl() ?: $product->getProductUrl();
             return $this->builderTools->replaceLocalUrlWithDummyUrl($url);
         } else {
             return $this->trimAttribute(self::ATTR_URL, $link);


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
When we have configurable products with simples which are not visible individually we must get parent product url to push proper link to all children. This is correctly defined in ProductRepository https://github.com/magento/meta-for-magento2/blob/9b12569141be385d6e264eb4c456d1d936745f4e/app/code/Meta/Catalog/Model/ProductRepository.php#L94
but on the next line we make all products visible...
https://github.com/magento/meta-for-magento2/blob/9b12569141be385d6e264eb4c456d1d936745f4e/app/code/Meta/Catalog/Model/ProductRepository.php#L95
then validation in https://github.com/magento/meta-for-magento2/blob/9b12569141be385d6e264eb4c456d1d936745f4e/app/code/Meta/Catalog/Model/Product/Feed/Builder.php#L252 never will be true and "non visible" product will be returned in all cases.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento-commerce/facebook-for-magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Possible fixes: magento/meta-for-magento2#48

### Checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
