### PR TITLE
ADO-249 fixes to remove google_product_category on module uninstall

### DIFF
--- a/app/code/Meta/Catalog/Setup/Patch/Data/AddProductAttributes.php
+++ b/app/code/Meta/Catalog/Setup/Patch/Data/AddProductAttributes.php
@@ -9,8 +9,9 @@ use Magento\Framework\Setup\Patch\DataPatchInterface;
 use Magento\Eav\Setup\EavSetupFactory;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Meta\Catalog\Setup\MetaCatalogAttributes;
+use Magento\Framework\Setup\Patch\PatchRevertableInterface;
 
-class AddProductAttributes implements DataPatchInterface
+class AddProductAttributes implements DataPatchInterface, PatchRevertableInterface
 {
 
     /**


### PR DESCRIPTION
Git bug link - https://github.com/magento/meta-for-magento2/issues/24
ADO bug link - https://rightpoint.atlassian.net/browse/ADO-249


This fix will remove the product attribute "google_product_category" on uninstalling (below command) the meta/module-catalog module and prevents any further issues.

`bin/magento module:uninstall --remove-data --non-composer -v Meta_Catalog`