### PR TITLE
ADO-335 - Resolve issue on module reinstall related attributes should be recreated

### DIFF
--- a/app/code/Meta/Catalog/Setup/Patch/Data/AddCategoryAttributes.php
+++ b/app/code/Meta/Catalog/Setup/Patch/Data/AddCategoryAttributes.php
@@ -9,8 +9,9 @@ use Magento\Framework\Setup\Patch\DataPatchInterface;
 use Magento\Eav\Setup\EavSetupFactory;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Meta\Catalog\Setup\MetaCatalogAttributes;
+use Magento\Framework\Setup\Patch\PatchRevertableInterface;
 
-class AddCategoryAttributes implements DataPatchInterface
+class AddCategoryAttributes implements DataPatchInterface, PatchRevertableInterface
 {
     /**
      * @var ModuleDataSetupInterface
@@ -96,6 +97,8 @@ class AddCategoryAttributes implements DataPatchInterface
         foreach (array_keys($categoryAttributes) as $attributeCode) {
             $eavSetup->removeAttribute(Category::ENTITY, $attributeCode);
         }
+        //delete the patch entry from patch_list table
+        $this->moduleDataSetup->deleteTableRow('patch_list', 'patch_name', __CLASS__);
 
         $this->moduleDataSetup->getConnection()->endSetup();
     }

--- a/app/code/Meta/Catalog/Setup/Patch/Data/AddCategoryProductSetIdAttribute.php
+++ b/app/code/Meta/Catalog/Setup/Patch/Data/AddCategoryProductSetIdAttribute.php
@@ -9,8 +9,9 @@ use Magento\Framework\Setup\Patch\DataPatchInterface;
 use Magento\Eav\Setup\EavSetupFactory;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Meta\Catalog\Setup\MetaCatalogAttributes;
+use Magento\Framework\Setup\Patch\PatchRevertableInterface;
 
-class AddCategoryProductSetIdAttribute implements DataPatchInterface
+class AddCategoryProductSetIdAttribute implements DataPatchInterface, PatchRevertableInterface
 {
     /**
      * @var ModuleDataSetupInterface
@@ -96,7 +97,8 @@ class AddCategoryProductSetIdAttribute implements DataPatchInterface
         foreach (array_keys($categoryAttributes) as $attributeCode) {
             $eavSetup->removeAttribute(Category::ENTITY, $attributeCode);
         }
-
+        //delete the patch entry from patch_list table
+        $this->moduleDataSetup->deleteTableRow('patch_list', 'patch_name', __CLASS__);
         $this->moduleDataSetup->getConnection()->endSetup();
     }
 }

--- a/app/code/Meta/Catalog/Setup/Patch/Data/AddProductAttributes.php
+++ b/app/code/Meta/Catalog/Setup/Patch/Data/AddProductAttributes.php
@@ -9,8 +9,9 @@ use Magento\Framework\Setup\Patch\DataPatchInterface;
 use Magento\Eav\Setup\EavSetupFactory;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Meta\Catalog\Setup\MetaCatalogAttributes;
+use Magento\Framework\Setup\Patch\PatchRevertableInterface;
 
-class AddProductAttributes implements DataPatchInterface
+class AddProductAttributes implements DataPatchInterface, PatchRevertableInterface
 {
 
     /**

--- a/app/code/Meta/Catalog/Setup/Patch/Data/AddProductAttributes.php
+++ b/app/code/Meta/Catalog/Setup/Patch/Data/AddProductAttributes.php
@@ -109,7 +109,8 @@ class AddProductAttributes implements DataPatchInterface, PatchRevertableInterfa
         foreach (array_keys($productAttributes) as $attributeCode) {
             $eavSetup->removeAttribute(Product::ENTITY, $attributeCode);
         }
-
+        //delete the patch entry from patch_list table
+        $this->moduleDataSetup->deleteTableRow('patch_list', 'patch_name', __CLASS__);
         $this->moduleDataSetup->getConnection()->endSetup();
     }
 }

--- a/app/code/Meta/Catalog/Setup/Patch/Data/UpdateMetaCatalogSourceAttribute.php
+++ b/app/code/Meta/Catalog/Setup/Patch/Data/UpdateMetaCatalogSourceAttribute.php
@@ -4,8 +4,9 @@ namespace Meta\Catalog\Setup\Patch\Data;
 
 use Magento\Framework\Setup\Patch\DataPatchInterface;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
+use Magento\Framework\Setup\Patch\PatchRevertableInterface;
 
-class UpdateMetaCatalogSourceAttribute implements DataPatchInterface
+class UpdateMetaCatalogSourceAttribute implements DataPatchInterface, PatchRevertableInterface
 {
     /**
      * @var ModuleDataSetupInterface
@@ -85,6 +86,9 @@ class UpdateMetaCatalogSourceAttribute implements DataPatchInterface
         $this->moduleDataSetup->getConnection()->startSetup();
 
         $this->revertAttributeUpdate();
+
+        //delete the patch entry from patch_list table
+        $this->moduleDataSetup->deleteTableRow('patch_list', 'patch_name', __CLASS__);
 
         $this->moduleDataSetup->getConnection()->endSetup();
     }


### PR DESCRIPTION
Git bug link - https://github.com/magento/meta-for-magento2/issues/79
ADO bug link - https://rightpoint.atlassian.net/browse/ADO-335


On module reinstall all below related attributes will be recreated with this fix

google_product_category
send_to_facebook
meta_product_set_id
sync_to_facebook_catalog