### PR TITLE
Handling Response.backUrl Undefined in AddToCart

### DIFF
--- a/app/code/Meta/Conversion/view/frontend/templates/pixel/add_to_cart.phtml
+++ b/app/code/Meta/Conversion/view/frontend/templates/pixel/add_to_cart.phtml
@@ -62,7 +62,7 @@ $trackerUrl = $block->getTrackerUrl();
                     simpleProductId = productId;
                 }
                 const form_key = jQuery("[name='form_key']").val();
-                const runAsync = !data.response.backUrl;
+                const runAsync = !(data && data.response && data.response.backUrl);
                 $.ajax({
                     url: product_info_url,
                     data: {

--- a/app/code/Meta/Conversion/view/frontend/templates/pixel/add_to_cart.phtml
+++ b/app/code/Meta/Conversion/view/frontend/templates/pixel/add_to_cart.phtml
@@ -37,71 +37,72 @@ $trackerUrl = $block->getTrackerUrl();
                 let simpleProductId;
                 // Get id of last added product
                 const productId = data.productIds[data.productIds.length - 1];
-                    // check product data from swatch widget
-                    const swatchData = $('[data-role=swatch-options]').data('mage-SwatchRenderer');
-                    if (swatchData && swatchData.getProductId()) {
-                        simpleProductId = swatchData.getProductId();
+                // check product data from swatch widget
+                const swatchData = $('[data-role=swatch-options]').data('mage-SwatchRenderer');
+                if (swatchData && swatchData.getProductId()) {
+                    simpleProductId = swatchData.getProductId();
+                } else {
+                    // In case product is added from category page get options using added product's id
+                    const categorySwatchData = $('[data-role=swatch-option-' + productId + ']')
+                        .data('mage-SwatchRenderer');
+                    if (categorySwatchData && categorySwatchData.getProductId()) {
+                        simpleProductId = categorySwatchData.getProductId();
                     } else {
-                        // In case product is added from category page get options using added product's id
-                        const categorySwatchData = $('[data-role=swatch-option-' + productId + ']')
-                            .data('mage-SwatchRenderer');
-                        if (categorySwatchData && categorySwatchData.getProductId()) {
-                            simpleProductId = categorySwatchData.getProductId();
-                        } else {
-                            // else check product data from configurable options
-                            const configurableProduct = data.form.data().mageConfigurable;
-                            if (configurableProduct) {
-                                simpleProductId = configurableProduct.simpleProduct;
-                            }
+                        // else check product data from configurable options
+                        const configurableProduct = data.form.data().mageConfigurable;
+                        if (configurableProduct) {
+                            simpleProductId = configurableProduct.simpleProduct;
                         }
                     }
-                    // otherwise use the product sku
-                    const product_sku = data.sku;
-                    // use last added product id if swatch data is not available
-                    if (!simpleProductId) {
-                        simpleProductId = productId;
-                    }
-                    const form_key = jQuery("[name='form_key']").val();
-                    $.ajax({
-                        url: product_info_url,
-                        data: {
-                            product_sku: product_sku,
-                            product_id: simpleProductId,
-                            form_key: form_key
-                        },
-                        type: 'get',
-                        dataType: 'json',
-                        async: !data.response.backUrl,
-                        success: function (res) {
-                            const addToCartConfigPixel = {
-                                "url": window.addToCartData.url,
-                                "payload": {
-                                    "eventName": window.addToCartData.eventName,
-                                    "productId": res.productId
-                                },
-                                "browserEventData": {
-                                    'fbAgentVersion': window.addToCartData.fbAgentVersion,
-                                    'fbPixelId': window.addToCartData.fbPixelId,
-                                    'source': window.addToCartData.source,
-                                    'pluginVersion': window.addToCartData.pluginVersion,
-                                    'track': window.addToCartData.track,
-                                    'event': window.addToCartData.event,
-                                    'payload': {
-                                        "content_name": res.name,
-                                        "content_ids": [res.id],
-                                        "value": res.value,
-                                        "currency": res.currency,
-                                        "content_type": res.content_type,
-                                        "contents": [{
-                                            "id": res.id,
-                                            "quantity": 1
-                                        }]
-                                    }
+                }
+                // otherwise use the product sku
+                const product_sku = data.sku;
+                // use last added product id if swatch data is not available
+                if (!simpleProductId) {
+                    simpleProductId = productId;
+                }
+                const form_key = jQuery("[name='form_key']").val();
+                const runAsync = !data.response.backUrl;
+                $.ajax({
+                    url: product_info_url,
+                    data: {
+                        product_sku: product_sku,
+                        product_id: simpleProductId,
+                        form_key: form_key
+                    },
+                    type: 'get',
+                    dataType: 'json',
+                    async: runAsync,
+                    success: function (res) {
+                        const addToCartConfigPixel = {
+                            "url": window.addToCartData.url,
+                            "payload": {
+                                "eventName": window.addToCartData.eventName,
+                                "productId": res.productId
+                            },
+                            "browserEventData": {
+                                'fbAgentVersion': window.addToCartData.fbAgentVersion,
+                                'fbPixelId': window.addToCartData.fbPixelId,
+                                'source': window.addToCartData.source,
+                                'pluginVersion': window.addToCartData.pluginVersion,
+                                'track': window.addToCartData.track,
+                                'event': window.addToCartData.event,
+                                'payload': {
+                                    "content_name": res.name,
+                                    "content_ids": [res.id],
+                                    "value": res.value,
+                                    "currency": res.currency,
+                                    "content_type": res.content_type,
+                                    "contents": [{
+                                        "id": res.id,
+                                        "quantity": 1
+                                    }]
                                 }
-                            };
-                            metaPixelTracker(addToCartConfigPixel);
-                        }
-                    });
+                            }
+                        };
+                        metaPixelTracker(addToCartConfigPixel);
+                    }
+                });
             });
         });
     </script>

--- a/app/code/Meta/Conversion/view/frontend/templates/pixel/add_to_cart.phtml
+++ b/app/code/Meta/Conversion/view/frontend/templates/pixel/add_to_cart.phtml
@@ -62,7 +62,7 @@ $trackerUrl = $block->getTrackerUrl();
                     simpleProductId = productId;
                 }
                 const form_key = jQuery("[name='form_key']").val();
-                const runAsync = data?.response?.backUrl;
+                const runAsync = !data?.response?.backUrl;
                 $.ajax({
                     url: product_info_url,
                     data: {

--- a/app/code/Meta/Conversion/view/frontend/templates/pixel/add_to_cart.phtml
+++ b/app/code/Meta/Conversion/view/frontend/templates/pixel/add_to_cart.phtml
@@ -62,7 +62,7 @@ $trackerUrl = $block->getTrackerUrl();
                     simpleProductId = productId;
                 }
                 const form_key = jQuery("[name='form_key']").val();
-                const runAsync = !(data && data.response && data.response.backUrl);
+                const runAsync = data?.response?.backUrl;
                 $.ajax({
                     url: product_info_url,
                     data: {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->
Fixing bug on undefined backUrl parameter in the AddToCart pixel event.
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Responding to issue 94 by taking the boolean definition out of the json and into the const. This replicates previous behavior but should default to true or false.

Previous behavior explanation:
 In Magento, there is a configuration option called "Redirect to Cart After Add to Cart", which, when enabled, redirects users to the cart page after a product is added to the cart.
This functionality is implemented in script: https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/Catalog/view/frontend/web/js/catalog-add-to-cart.js#L120
It checks for the backUrl in the response and, if present, redirects the user to the specified URL.
However, this behavior caused an issue with the addToCart event tracking. We use the ajax:addToCart event to trigger an ajax call that retrieves product information, which is then sent to Meta. Since AJAX calls are asynchronous by default, the user was being redirected to the cart page before the ajax call would complete.
To address this, I added the async property to the ajax call. When a backUrl is present in the response, the ajax call is made synchronous to ensure it completes fully before the redirection to the cart page occurs.

### Story
<!--- 
* [<issue_number>](<issue_link>) <issue_title>
-->

### Bug
<!--- 
* [94](https://github.com/magento/meta-for-magento2/issues/94) <Cannot read properties of undefined (reading 'backUrl')>
-->
[94](https://github.com/magento/meta-for-magento2/issues/94) <Cannot read properties of undefined (reading 'backUrl')>
### Task
<!--- 
* [<issue_number>](<issue_link>) <issue_title>
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento-commerce/facebook-for-magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento-commerce/facebook-for-magento2#<issue_number>: Issue title


### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
There are two relevant variables: Redirect to Cart After Add to Cart (RedirectEnabled for short) and the backUrl value. Will test all 4 combinations of those two by toggling Redirect Enabled from local admin panel and then altering backUrl value from browser source file. 
1. RedirectEnabled = true, backUrl="http://44.245.119.204/": redirected to the homepage as expected and pixel addToCart recorded: 
![image](https://github.com/user-attachments/assets/ffb5cac2-7cd4-4554-bc26-f9afdb2b24d7)

2. RedirectEnabled = true, backUrl=undefined or empty string; Redirected to cart (expected) and pixel addToCart recorded.
3. RedirectEnabled = false, backUrl="http://44.245.119.204/": Stayed on PDP where I was. Makes sense, redirect is not enabled. AddToCart pixel event recorded.
4.  RedirectEnabled = false, backUrl=undefined or empty string; Same as above.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
Why sync if there is a backUrl and async if not? I am replicating the existing behavior but it does not make intuitive sense to me.
### Checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
