### PR TITLE
Fix return type in isInstalledShopOnsiteEligible() to ensure boolean

### DIFF
--- a/app/code/Meta/BusinessExtension/Model/System/Config.php
+++ b/app/code/Meta/BusinessExtension/Model/System/Config.php
@@ -1057,7 +1057,7 @@ class Config
      */
     public function isInstalledShopOnsiteEligible(int $storeId = null): bool
     {
-        return $this->getConfig(self::XML_PATH_FACEBOOK_BUSINESS_EXTENSION_IS_ONSITE_ELIGIBLE, $storeId);
+        return (bool) $this->getConfig(self::XML_PATH_FACEBOOK_BUSINESS_EXTENSION_IS_ONSITE_ELIGIBLE, $storeId);
     }
 
     /**


### PR DESCRIPTION
### Description (*)
This pull request ensures the `isInstalledShopOnsiteEligible` method always returns a boolean value.

Previously, the method returned the raw configuration value, which may be a string or null. This change explicitly casts the return value to a boolean to prevent potential type mismatches and ensure consistent behavior across usages.

### Fixed Issues (if relevant)
#106 

### Manual testing scenarios (*)
1. Ensure that the `isInstalledShopOnsiteEligible` method correctly returns `true` or `false` depending on the configuration value set in the backend.
2. Verify that all features relying on this method behave as expected without type warnings or logic inconsistencies.

### Questions or comments
If this method is used in type-sensitive contexts (e.g., strict comparisons), this change guarantees proper behavior.

### Checklist
- [x] Pull request has a meaningful description of its purpose  
- [x] All commits are accompanied by meaningful commit messages  
- [ ] All new or changed code is covered with unit/integration tests (if applicable)  
- [x] All automated tests passed successfully (all builds are green)
